### PR TITLE
 fix: add 0x formatted to in result of unsigner

### DIFF
--- a/packages/appchain-signer/lib/unsigner.js
+++ b/packages/appchain-signer/lib/unsigner.js
@@ -28,6 +28,9 @@ const unsigner = (hexUnverifiedTransaction) => {
             break;
         }
     }
+    if (transaction.to) {
+        transaction.to = '0x' + transaction.to;
+    }
     const sign = new Signature({
         r: index_1.bytes2hex(signature.slice(0, 32)).slice(2),
         s: index_1.bytes2hex(signature.slice(32, 64)).slice(2),

--- a/packages/appchain-signer/src/unsigner.ts
+++ b/packages/appchain-signer/src/unsigner.ts
@@ -33,6 +33,9 @@ const unsigner = (hexUnverifiedTransaction: string) => {
       break
     }
   }
+  if (transaction.to) {
+    transaction.to = '0x' + transaction.to
+  }
 
   const sign = new Signature({
     r: bytes2hex(signature.slice(0, 32)).slice(2),

--- a/packages/appchain-signer/test/index.test.js
+++ b/packages/appchain-signer/test/index.test.js
@@ -101,13 +101,15 @@ describe('tests for cita v0', () => {
 })
 
 test('unsign', () => {
-  const signedMsg = sign(tx, privateKey)
+  const signedMsg = sign({ ...tx,
+    to: from
+  }, privateKey)
   const {
     transaction,
     crypto,
     sender
   } = unsign(signedMsg)
-  expect(transaction.to).toBe('')
+  expect(transaction.to).toBe(from.toLowerCase())
   expect(transaction.validUntilBlock).toBe(tx.validUntilBlock)
   expect(transaction.version.toString()).toBe(tx.version)
   expect(transaction.chainId).toBe(tx.chainId)


### PR DESCRIPTION
add `0x` to `to` address of result from unsigner